### PR TITLE
Implement needreload ignorelist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,9 @@ Following configuration options are supported:
 
 * ``ScanNeedReload``: monitor the needreload status of all units (off by default)
 
-* ``NeedReloadIgnore``: One or more systemd units to ignore the NeedReload status of (empty by default)
+* ``NeedReloadIgnore``: Space separated list of one or more systemd units to ignore the NeedReload status of (empty by default) e.g.::
+
+    NeedReloadIgnore "service1.service" "tmp.mount"
 
 * ``Interval``: check interval. It's ok to keep the default (60 seconds)
 

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,8 @@ Following configuration options are supported:
 
 * ``ScanNeedReload``: monitor the needreload status of all units (off by default)
 
+* ``NeedReloadIgnore``: One or more systemd units to ignore the NeedReload status of (empty by default)
+
 * ``Interval``: check interval. It's ok to keep the default (60 seconds)
 
 * ``Verbose``: enable verbose logging (off by default)

--- a/README.rst
+++ b/README.rst
@@ -91,14 +91,14 @@ Metrics and Debug
 systemd-sshd/gauge-running
 ##########################
 
-Each configured service (e.g. sshd) will be reported. If the value is less than one check
+Each configured service (e.g. sshd) will be reported. If the value is less than one check::
 
     systemctl status sshd
 
 systemd-systemd-state/boolean-running
 #####################################
 
-Each node will be report this value. If the value is less than one check
+Each node will be report this value. If the value is less than one check::
 
     systemctl status 
     systemctl --state=failed
@@ -106,11 +106,11 @@ Each node will be report this value. If the value is less than one check
 systemd-needreload/boolean-NeedDaemonReload
 ###########################################
 
-Each node will report this value. If less than one then identify stale unit by looking in collectd log file for an entry
+Each node will report this value. If less than one then identify stale unit by looking in collectd log file for an entry::
 
     systemd plugin [info]: Unit needs reload: certmgr-renew.timer
 
-or by running the command
+or by running the command::
 
     for U in $(systemctl --no-pager --no-legend | awk '{print $1}' ) ; do
       systemctl show -p NeedDaemonReload -- $U  | grep -q yes && echo $U

--- a/collectd_systemd.py
+++ b/collectd_systemd.py
@@ -7,6 +7,7 @@ class SystemD(object):
         self.interval = 60.0
         self.verbose_logging = False
         self.scan_needreload = False
+        self.needreload_ignore = []
         self.services = []
         self.units = {}
         self.manager_properties = None
@@ -84,6 +85,8 @@ class SystemD(object):
         need_reload = False
         for unit in units:
             name, _, _, _, _, _, path, _, _, _ = unit
+            if name in self.needreload_ignore:
+                continue
             unit = self.get_unit(name, path=path)
             try:
                 rel = unit.Get('org.freedesktop.systemd1.Unit', 'NeedDaemonReload')
@@ -120,6 +123,8 @@ class SystemD(object):
                 self.verbose_logging = (vals[0].lower() == 'true')
             elif node.key == 'ScanNeedReload':
                 self.scan_needreload = (vals[0].lower() == 'true')
+            elif node.key == 'NeedReloadIgnore':
+                self.needreload_ignore.extend(vals)
             else:
                 raise ValueError('{} plugin: Unknown config key: {}'
                                  .format(self.plugin_name, node.key))


### PR DESCRIPTION
Implement an ignore list for the needreload alert. Useful in cases where one unit is misbehaving.

Additionally, convert all the quote blocks in the README to code blocks for better formatting.