### PR TITLE
Consider an auto-restart unit as okay

### DIFF
--- a/collectd_systemd.py
+++ b/collectd_systemd.py
@@ -176,7 +176,7 @@ class SystemD(object):
                 self.init_dbus()
                 state = self.get_service_state(full_name)
 
-            value = (1.0 if state == 'running' or state == 'reload' or state == 'start' or ( state == 'dead' and type == 'oneshot' ) else 0.0)
+            value = (1.0 if state == 'running' or state == 'auto-restart' or state == 'reload' or state == 'start' or ( state == 'dead' and type == 'oneshot' ) else 0.0)
             self.log_verbose('Sending value: {}.{}={} (state={}, type={})'
                              .format(self.plugin_name, name, value, state, type))
             val = collectd.Values(


### PR DESCRIPTION
Once a unit enters auto-restart status it is considered as a failed unit by this monitor.

```
Active: activating (auto-restart) (Result: exit-code) since Tue
2024-02-27 09:52:14 CET; 3min 37s ago
```

Consider units in this state to be good.

It is up to the unit author to ensure restarts are not infinite.