### PR TITLE
New StateIgnoreRegex ignores units from status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,8 @@ Following configuration options are supported:
 
     NeedReloadIgnore "service1.service" "tmp.mount"
 
+* ``StateIgnoreRegex``: Regexes of unit names to ignore from the global systemd status e.g. '^user@\d+\.service$'
+
 * ``Interval``: check interval. It's ok to keep the default (60 seconds)
 
 * ``Verbose``: enable verbose logging (off by default)


### PR DESCRIPTION
Previously this module relied on `systemd status` to check the global status of systemd units.

Instead loop over each unit and if any unit is failed consider the whole systemd_state as broken.

In particular this allows a new configuration option:

```
StateIgnoreRegex  '^user@\d+\.service$' 'cvmfs_fsck.service'
```

to be ignored from influencing the global state.