### PR TITLE
Make get_system_state send broken when iface fails

### DIFF
--- a/collectd_systemd.py
+++ b/collectd_systemd.py
@@ -76,7 +76,7 @@ class SystemD(object):
         except dbus.exceptions.DBusException as e:
             collectd.warning('{} plugin: failed to list units: {}'.format(
                 self.plugin_name, e))
-            system_state = 'broken'
+            return 'broken'
 
         for unit in units:
             name, _, _, _, _, _, path, _, _, _ = unit


### PR DESCRIPTION
Without this change, the plugin will fail to fetch the system state if there was a reload/reexec of systemd.

In the current state, if there is an error, the execution continues with "units" not initialized making the following block fail with:

```
UnboundLocalError: local variable 'units' referenced before assignment
```

This patch makes the function return "broken" early enough as expected when there is an issue. The calling function will re-try the call with the "broken" status. This should be enough to fix the common case of systemd being reload by updates, etc.